### PR TITLE
fix jDataView dep and mp4 downloading with incorrect filename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3342,16 +3342,15 @@
     },
     "jDataView": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jDataView/-/jDataView-2.3.0.tgz",
+      "resolved": "github:jDataView/jDataView#c9c29eac67c54de78ac48d16e5dffc5194a0c7bf",
       "integrity": "sha1-5jwZcv3J5u4Bxt64aMYZaQToE+A=",
       "requires": {
         "jdataview": "*"
       }
     },
     "jdataview": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jdataview/-/jdataview-2.5.0.tgz",
-      "integrity": "sha1-MIGz/qZR+TF+xr1P6y3cmKpB1ZU="
+      "version": "github:jDataView/jDataView#c9c29eac67c54de78ac48d16e5dffc5194a0c7bf",
+      "from": "github:jDataView/jDataView"
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "filenamify": "^4.2.0",
     "https-browserify": "^1.0.0",
     "jDataView": "^2.3.0",
+    "jdataview": "github:jDataView/jDataView",
     "lodash-es": "^4.17.20",
     "mime-types": "^2.1.28",
     "path-browserify": "^1.0.1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,11 +30,13 @@ export default {
         format.mimeType,
         tags
       )
-      chrome.downloads.download({
-        url: URL.createObjectURL(blob),
-        filename: `${filenamify(ytVideoInfo.videoDetails.title)}.${mime.extension(format.mimeType)}`
-      })
-    })
+      const filename = `${filenamify(ytVideoInfo.videoDetails.title)}.${mime.extension(format.mimeType)}`;
+      const link = document.createElement('a');
+      link.download = filename;
+      link.href = URL.createObjectURL(blob, { type: 'text/plain;charset=UTF-8' });
+      link.dispatchEvent(new MouseEvent('click'));
+      URL.revokeObjectURL(link.href);
+    });
   },
   async setBlobTags (blob, mimeType, tags) {
     let fileBuffer


### PR DESCRIPTION
1. For some reason jDataView seems to have a broken npm package now so I switched that to use GitHub directly.
2. mp4s were hitting this bug so I added a work around https://bugs.chromium.org/p/chromium/issues/detail?id=892133#c_ts1620794357